### PR TITLE
Fix Vue type warning in panel

### DIFF
--- a/src/components/Colors.vue
+++ b/src/components/Colors.vue
@@ -59,7 +59,7 @@ export default {
         label: String,
         value: String,
         contrast: [Boolean, Array],
-        contrastColors: Array,
+        contrastColors: [Array, Boolean],
         readability: Boolean,
         alpha: Boolean,
         invalid: Boolean,


### PR DESCRIPTION
 The `contrastColors` js prop can also be a `bool` according to the equivalent php prop code.
 https://github.com/hananils/kirby-colors/blob/9166d1ef1e66fbfca0860012354a950d61676511/index.php#L26-L28
 
 When the panel is in `npm run dev` mode, it showed a type warning in the console.