### PR TITLE
Fix #27 : Translatable `help` blueprint

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ Kirby::plugin('hananils/kirby-colors', [
                     return is_array($value) ? $value[0] : $value;
                 },
                 'help' => function ($help = null) {
-                    return $help;
+                    return I18n::translate($help, $help);
                 },
                 'alpha' => function (bool $alpha = false) {
                     return $alpha;


### PR DESCRIPTION
The help field wasn't translatable as the other textual field props are.
Fully retro-compatible with non-translated values.
Fixes #27 